### PR TITLE
fix FLOAT_EQ problem

### DIFF
--- a/src/MKVCacheServer/MKCacheComm.cpp
+++ b/src/MKVCacheServer/MKCacheComm.cpp
@@ -1015,7 +1015,8 @@ void BinToDbValue(const string &sMK, const string &sUK, const string &sValue, in
 
 
 const double EPSILON = 1.00e-07;
-#define FLOAT_EQ(x,v) (((v - EPSILON) < x) && (x <( v + EPSILON)))
+//#define FLOAT_EQ(x,v) (((v - EPSILON) <= x) && (x <=( v + EPSILON)))
+#define FLOAT_EQ(x,v) (fabs((x) - (v)) <= EPSILON)
 
 bool judgeValue(TarsDecode &decode, const string &value, Op op, const string &type, uint8_t tag, const string &sDefault, bool isRequire)
 {


### PR DESCRIPTION
考虑大整数的情况
1600000000000 - EPSILON = 1600000000000
1600000000000 - EPSILON = 1600000000000

#define FLOAT_EQ(x,v) (((v - EPSILON) < x) && (x <( v + EPSILON))) 会出现
FLOAT_EQ(1600000000000， 1600000000000) 计算结果为false。

直接使用 == 或者用修改后的代码实际会更合适