### PR TITLE
删除数据时，跳过正在分配的block，需要重置mainkey

### DIFF
--- a/src/MKVCacheServer/jmem_multi_hashmap_malloc/tc_multi_hashmap_malloc.cpp
+++ b/src/MKVCacheServer/jmem_multi_hashmap_malloc/tc_multi_hashmap_malloc.cpp
@@ -11447,6 +11447,8 @@ namespace DCache
             {
                 // 当前主key链中有正在分配的block，跳过
                 iAddr = mainKey.getHeadPtr()->_iGetPrev;
+                MainKey tmp(this, iAddr);                                                                
+                mainKey = tmp;
             }
             if (iAddr == 0)
             {


### PR DESCRIPTION
如题， 只需要重置一下mainkey.
另外，在eraseExcept执行多次删除mainkey时，最后一个总是删除，代码逻辑更好理解一些， 改动的代码如下：
(以下的改动没有提交pr，仅供参考)
```

 // 不管是按get链淘汰还是按set链淘汰，都是要淘汰主key下所有数据                               
        MainKey mainKey(this, iAddr);                                                                
        if (iNowAddr == iAddr)                                                                       
        {                                                                                            
            // 当前主key链中有正在分配的block，跳过                                                  
            iAddr = mainKey.getHeadPtr()->_iGetPrev;                                                 
            MainKey tmp(this, iAddr);                                                                
            mainKey = tmp;                                                                           
        }                                                                                            
        if (iAddr == 0)                                                                              
        {                                                                                            
            break;                                                                                   
        }                                                                                            
                                                                                                     
        uint32_t iBlockCount = mainKey.getHeadPtr()->_iBlockCount;                                   
        if (d >= iBlockCount)                                                                        
        {                                                                                            
            // 淘汰主key链下的所有数据                                                               
            int ret = mainKey.erase(vtData);                                                         
            if (ret == RT_OK)                                                                        
            {                                                                                        
                d -= iBlockCount;                                                                    
            }                                                                                        
        }                                                                                            
        else                                                                                         
        {                                                                                            
            // 设置的要删除的数量太小，没有满足条件的主key，直接删除                                 
            int ret = mainKey.erase(vtData);                                                         
            if (ret == RT_OK) {                                                                      
                // 第一次删除                                                                        
                if (d == n) {                                                                        
                    n = d + iBlockCount;    // 使返回正确的数据量                                    
                } else {                                                                             
                    n += iBlockCount - d;                                                            
                    d = 0;                                                                           
                }                                                                                    
            }                                                                                        
            break;                                                                                   
        }
```