### PR TITLE
fix make error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 include_directories(/usr/local/tars/cpp/thirdparty/include)
 link_directories(/usr/local/tars/cpp/thirdparty/lib)
+link_libraries(pthread)
 
 add_subdirectory(src)
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 include_directories(/usr/local/tars/cpp/thirdparty/include)
 link_directories(/usr/local/tars/cpp/thirdparty/lib)
 link_libraries(pthread)
+link_libraries(dl)
+
 
 add_subdirectory(src)
 add_subdirectory(test)


### PR DESCRIPTION
```
gtest-all.cc:(.text._ZN7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEE9CreateKeyEv[_ZN7testing8internal11ThreadLocalISt6vectorINS0_9TraceInfoESaIS3_EEE9CreateKeyEv]+0x16)：对‘pthread_key_create’未定义的引用
/usr/local/tars/cpp/thirdparty/lib64/libgtest.a(gtest-all.cc.o)：在函数‘testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::GetOrCreateValue() const’中：
gtest-all.cc:(.text._ZNK7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEE16GetOrCreateValueEv[_ZNK7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEE16GetOrCreateValueEv]+0x16)：对‘pthread_getspecific’未定义的引用
gtest-all.cc:(.text._ZNK7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEE16GetOrCreateValueEv[_ZNK7testing8internal11ThreadLocalIPNS_31TestPartResultReporterInterfaceEE16GetOrCreateValueEv]+0x79)：对‘pthread_setspecific’未定义的引用
collect2: 错误：ld 返回 1
make[2]: *** [bin/test-TimerThreadTest] 错误 1
make[1]: *** [test/Proxy/CMakeFiles/test-TimerThreadTest.dir/all] 错误 2



```