### PR TITLE
Fix/beyond wuxf/test link ssl

### DIFF
--- a/test/KVCacheServer/CMakeLists.txt
+++ b/test/KVCacheServer/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(TEST_CPP ${TEST_CPPS})
 
     add_executable(test-${TEST_NAME} ${TEST_CPP})
 
-    target_link_libraries(test-${TEST_NAME} mysqlclient gtest gmock tarsservant libKVCacheServer cache_comm tarsutil ${ZLIB_LIBRARIES})
+    target_link_libraries(test-${TEST_NAME} mysqlclient gtest gmock tarsservant libKVCacheServer cache_comm tarsutil ${ZLIB_LIBRARIES} ssl crypto)
 
     add_dependencies(test-${TEST_NAME} libKVCacheServer cache_comm TarsComm ProxyServer RouterServer KVCacheServer MKVCacheServer)
 

--- a/test/Proxy/CMakeLists.txt
+++ b/test/Proxy/CMakeLists.txt
@@ -14,7 +14,7 @@ foreach(TEST_CPP ${TEST_CPPS})
 
     add_executable(test-${TEST_NAME} ${TEST_CPP})
 
-    target_link_libraries(test-${TEST_NAME} mysqlclient gtest gmock libProxy cache_comm tarsservant tarsutil)
+    target_link_libraries(test-${TEST_NAME} mysqlclient gtest gmock libProxy cache_comm tarsservant tarsutil ssl crypto)
 
     add_dependencies(test-${TEST_NAME} libProxy cache_comm TarsComm ProxyServer RouterServer KVCacheServer MKVCacheServer)
 

--- a/test/Router/CMakeLists.txt
+++ b/test/Router/CMakeLists.txt
@@ -14,7 +14,7 @@ foreach(TEST_CPP ${TEST_CPPS})
 
     add_executable(test-${TEST_NAME} ${TEST_CPP})
 
-    target_link_libraries(test-${TEST_NAME} gtest gmock libRouter cache_comm tarsservant tarsutil mysqlclient)
+    target_link_libraries(test-${TEST_NAME} gtest gmock libRouter cache_comm tarsservant tarsutil mysqlclient ssl crypto)
 
     add_dependencies(test-${TEST_NAME} libRouter cache_comm TarsComm ProxyServer RouterServer KVCacheServer MKVCacheServer)
 


### PR DESCRIPTION
如果编译tarscpp是使用用TARS_SSL=ON，链接时会出现找不到ssl库函数的错误